### PR TITLE
Support hover + signatureHelp

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ node dist/cli.js --root samples/rust-basic --format json references samples/rust
 
 # definition（rust-analyzerの初期化直後は結果が空になることがあるのでwait推奨）
 node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 definition samples/rust-basic/src/main.rs 8 12
+
+# hover
+node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 hover samples/rust-basic/src/main.rs 8 12
+
+# signature help（add( の中あたり）
+node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 signature-help samples/rust-basic/src/main.rs 8 16
 ```
 
 ## Notes

--- a/src/lsp/LspClient.ts
+++ b/src/lsp/LspClient.ts
@@ -78,6 +78,8 @@ export class LspClient {
               definition: {},
               implementation: {},
               typeDefinition: {},
+              hover: {},
+              signatureHelp: {},
               rename: {},
               codeAction: {}
             }


### PR DESCRIPTION
Adds:\n- textDocument/hover (command: hover)\n- textDocument/signatureHelp (command: signature-help)\n\nPretty output is optimized for terminal usage; JSON output stays raw.\n\nCloses #3.