### PR TITLE
Make lsp-cli installable as a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,24 @@
 npm install
 npm run build
 
+# repo をローカルにCLIとして入れる（lsp-cli コマンドが生える）
+npm link
+
 # 疎通（rust-analyzerがPATHに必要）
 # rustupプロキシの場合は先に:
 #   rustup component add rust-analyzer
-node dist/cli.js --root . ping
+lsp-cli --root . ping
 
 # documentSymbol（line/colは0-based）
-node dist/cli.js --root . --format pretty symbols path/to/file.rs
+lsp-cli --root . --format pretty symbols path/to/file.rs
+```
+
+### (planned) npx
+
+公開後は以下で動かす想定です:
+
+```bash
+npx @mako10k/lsp-cli --root . ping
 ```
 
 ## Sample (for testing)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lsp-cli",
+  "name": "@mako10k/lsp-cli",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lsp-cli",
+      "name": "@mako10k/lsp-cli",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
-  "name": "lsp-cli",
+  "name": "@mako10k/lsp-cli",
   "version": "0.0.1",
-  "private": true,
   "description": "Lightweight CLI for driving arbitrary LSP servers (MVP: rust-analyzer)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "lsp-cli": "dist/cli.js"
   },
+  "files": [
+    "dist/**/*"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build",
     "start": "node dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && node --test dist/test/**/*.test.js"


### PR DESCRIPTION
- Set package name to @mako10k/lsp-cli for eventual `npx @mako10k/lsp-cli` usage\n- Ensure `lsp-cli` bin points at dist/cli.js\n- Build on `npm pack`/publish via `prepack`\n- Update README to use `lsp-cli` directly