### PR TITLE
docs: use npx @mako10k/lsp-cli in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,24 @@
 ## Quickstart
 
 ```bash
+# 疎通（rust-analyzerがPATHに必要）
+# rustupプロキシの場合は先に:
+#   rustup component add rust-analyzer
+npx @mako10k/lsp-cli --root . ping
+
+# documentSymbol（line/colは0-based）
+npx @mako10k/lsp-cli --root . --format pretty symbols path/to/file.rs
+```
+
+### Development (from source)
+
+```bash
 npm install
 npm run build
 
 # repo をローカルにCLIとして入れる（lsp-cli コマンドが生える）
 npm link
-
-# 疎通（rust-analyzerがPATHに必要）
-# rustupプロキシの場合は先に:
-#   rustup component add rust-analyzer
-lsp-cli --root . ping
-
-# documentSymbol（line/colは0-based）
-lsp-cli --root . --format pretty symbols path/to/file.rs
-```
-
-### (planned) npx
-
-公開後は以下で動かす想定です:
-
-```bash
-npx @mako10k/lsp-cli --root . ping
+lsp-cli --help
 ```
 
 ## Sample (for testing)
@@ -38,26 +35,26 @@ Rustの簡易サンプルを同梱しています:
 
 ```bash
 # initialize疎通
-node dist/cli.js --root samples/rust-basic ping
+npx @mako10k/lsp-cli --root samples/rust-basic ping
 
 # documentSymbol
-node dist/cli.js --root samples/rust-basic --format pretty symbols samples/rust-basic/src/math.rs
+npx @mako10k/lsp-cli --root samples/rust-basic --format pretty symbols samples/rust-basic/src/math.rs
 
 # references: main.rs 内の add 呼び出し位置（0-based）
 # 例: 9行目の "add" の a 位置（"    let x = add(1, 2);"）
-node dist/cli.js --root samples/rust-basic --format json references samples/rust-basic/src/main.rs 8 12
+npx @mako10k/lsp-cli --root samples/rust-basic --format json references samples/rust-basic/src/main.rs 8 12
 
 # definition（rust-analyzerの初期化直後は結果が空になることがあるのでwait推奨）
-node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 definition samples/rust-basic/src/main.rs 8 12
+npx @mako10k/lsp-cli --root samples/rust-basic --format pretty --wait-ms 500 definition samples/rust-basic/src/main.rs 8 12
 
 # hover
-node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 hover samples/rust-basic/src/main.rs 8 12
+npx @mako10k/lsp-cli --root samples/rust-basic --format pretty --wait-ms 500 hover samples/rust-basic/src/main.rs 8 12
 
 # signature help（add( の中あたり）
-node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 signature-help samples/rust-basic/src/main.rs 8 16
+npx @mako10k/lsp-cli --root samples/rust-basic --format pretty --wait-ms 500 signature-help samples/rust-basic/src/main.rs 8 16
 
 # workspace symbols
-node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 ws-symbols add --limit 20
+npx @mako10k/lsp-cli --root samples/rust-basic --format pretty --wait-ms 500 ws-symbols add --limit 20
 ```
 
 ## Notes
@@ -98,7 +95,7 @@ node dist/cli.js --root samples/rust-basic --format pretty --wait-ms 500 ws-symb
 使い方:
 
 ```bash
-node dist/cli.js --root samples/rust-basic --config .lsp-cli.json ping
+npx @mako10k/lsp-cli --root samples/rust-basic --config .lsp-cli.json ping
 ```
 
 ### Examples (stdin / jq)
@@ -106,9 +103,9 @@ node dist/cli.js --root samples/rust-basic --config .lsp-cli.json ping
 ```bash
 # stdinでfileパスを渡す
 printf '%s\n' samples/rust-basic/src/math.rs \
-  | node dist/cli.js --root samples/rust-basic --jq 'length' symbols -
+  | npx @mako10k/lsp-cli --root samples/rust-basic --jq 'length' symbols -
 
 # JSON stdinでreferences入力を渡す
 printf '{"file":"samples/rust-basic/src/main.rs","line":8,"col":12}' \
-  | node dist/cli.js --root samples/rust-basic --stdin --jq '.[0]' references
+  | npx @mako10k/lsp-cli --root samples/rust-basic --stdin --jq '.[0]' references
 ```


### PR DESCRIPTION
Update README examples to use `npx @mako10k/lsp-cli` now that the package is published.\n\nKeep a short section for local development via `npm link`.