### PR TITLE
Code actions: select/apply by kind or title

### DIFF
--- a/src/mock/mockLspServer.ts
+++ b/src/mock/mockLspServer.ts
@@ -56,7 +56,8 @@ async function onRequest(req: JsonRpcRequest) {
           textDocumentSync: { openClose: true, change: 2 },
           documentSymbolProvider: true,
           referencesProvider: true,
-          renameProvider: true
+          renameProvider: true,
+          codeActionProvider: true
         }
       });
 
@@ -94,6 +95,35 @@ async function onRequest(req: JsonRpcRequest) {
           ]
         }
       });
+
+    case "textDocument/codeAction": {
+      const uri = req.params?.textDocument?.uri;
+      return respond(req.id, [
+        {
+          title: "Mock edit action",
+          kind: "quickfix.mock.edit",
+          isPreferred: true,
+          edit: {
+            changes: {
+              [uri ?? ""]: [
+                {
+                  range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                  newText: "E"
+                }
+              ]
+            }
+          }
+        },
+        {
+          title: "Mock command action",
+          kind: "refactor.mock.command",
+          command: {
+            command: "mock/applyEdit",
+            arguments: [{ uri, newText: "C" }]
+          }
+        }
+      ]);
+    }
 
     case "workspace/executeCommand": {
       if (req.params?.command === "mock/applyEdit") {

--- a/src/test/cli.codeActionsSelect.test.ts
+++ b/src/test/cli.codeActionsSelect.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+test("cli code-actions can auto-select by kind/title and apply", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "lsp-cli-cli-"));
+  const file = path.join(root, "a.txt");
+  await fs.writeFile(file, "hello\n", "utf8");
+
+  const serverScript = path.resolve(__dirname, "../mock/mockLspServer.js");
+
+  const cfgPath = path.join(root, "lsp-cli.config.json");
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify(
+      {
+        servers: {
+          mock: {
+            command: process.execPath,
+            args: [serverScript],
+            defaultLanguageId: "plaintext"
+          }
+        }
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  const cli = path.resolve(__dirname, "../cli.js");
+
+  // Apply the edit-based action (preferred)
+  {
+    const res = spawnSync(process.execPath, [cli, "--root", root, "--server", "mock", "--format", "json", "code-actions", file, "0", "0", "0", "0", "--apply", "--preferred", "--first"], {
+      encoding: "utf8"
+    });
+    assert.equal(res.status, 0, res.stderr);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.applied, true);
+    assert.equal(out.via, "edit");
+
+    const updated = await fs.readFile(file, "utf8");
+    assert.equal(updated, "Ehello\n");
+  }
+
+  // Apply the command-based action by kind
+  {
+    const res = spawnSync(process.execPath, [cli, "--root", root, "--server", "mock", "--format", "json", "code-actions", file, "0", "0", "0", "0", "--apply", "--kind", "refactor.mock", "--first"], {
+      encoding: "utf8"
+    });
+    assert.equal(res.status, 0, res.stderr);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.applied, true);
+    assert.equal(out.via, "command");
+
+    const updated = await fs.readFile(file, "utf8");
+    assert.equal(updated, "CEhello\n");
+  }
+
+  // Dry-run select by title-regex
+  {
+    const res = spawnSync(process.execPath, [cli, "--root", root, "--server", "mock", "--format", "json", "code-actions", file, "0", "0", "0", "0", "--title-regex", "Mock edit", "--first"], {
+      encoding: "utf8"
+    });
+    assert.equal(res.status, 0, res.stderr);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.dryRun, true);
+    assert.equal(out.index, 0);
+  }
+});


### PR DESCRIPTION
Adds selection flags for code-actions so scripts can apply actions without relying on numeric indexes. Includes a CLI integration test using the mock server.\n\nCloses #26.