### PR TITLE
Batch mode: JSONL long-lived session

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ npx @mako10k/lsp-cli --root samples/rust-basic --format pretty --wait-ms 500 ws-
 
 - 変更適用はデフォルト dry-run で、`--apply` 指定時のみファイルを書き換えます。
 
+### Batch mode (JSONL)
+
+stdin から JSON Lines（1行=1リクエスト）を読み、同一LSPセッションで順に実行します。
+
+```bash
+cat <<'JSONL' | npx @mako10k/lsp-cli --root . --server typescript-language-server --format json batch
+{"cmd":"references","file":"src/index.ts","line":0,"col":0}
+{"cmd":"definition","file":"src/index.ts","line":0,"col":0}
+JSONL
+```
+
+編集/リファクタを適用する場合は `batch --apply` を付けます（安全のため明示指定が必要）:
+
+```bash
+cat <<'JSONL' | npx @mako10k/lsp-cli --root . --server typescript-language-server --format json batch --apply
+{"cmd":"rename","file":"src/index.ts","line":0,"col":0,"newName":"renamed","apply":true}
+JSONL
+```
+
 ### Structured edit (delete symbol)
 
 `documentSymbol` を使ってシンボル名からブロック単位で削除します（dry-run例）:

--- a/src/mock/mockLspServer.ts
+++ b/src/mock/mockLspServer.ts
@@ -9,6 +9,7 @@ type JsonRpcResponse = { jsonrpc: "2.0"; id: number | string; result?: any; erro
 
 let lastDidOpen: any = null;
 let lastDidChange: any = null;
+let initializeCount = 0;
 
 let serverReqSeq = 0;
 const pending = new Map<number | string, (res: JsonRpcResponse) => void>();
@@ -50,6 +51,7 @@ function respondError(id: number | string, message: string) {
 async function onRequest(req: JsonRpcRequest) {
   switch (req.method) {
     case "initialize":
+      initializeCount++;
       return respond(req.id, {
         capabilities: {
           // Prefer incremental so LspClient exercises didChange incremental.
@@ -157,6 +159,9 @@ async function onRequest(req: JsonRpcRequest) {
 
     case "mock/getLastDidChange":
       return respond(req.id, lastDidChange);
+
+    case "mock/getInitializeCount":
+      return respond(req.id, initializeCount);
 
     default:
       return respondError(req.id, `mock server: unsupported method: ${req.method}`);

--- a/src/test/cli.batch.test.ts
+++ b/src/test/cli.batch.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+test("cli batch runs multiple requests in one LSP session", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "lsp-cli-batch-"));
+  const file = path.join(root, "a.txt");
+  await fs.writeFile(file, "hello\n", "utf8");
+
+  const serverScript = path.resolve(__dirname, "../mock/mockLspServer.js");
+
+  const cfgPath = path.join(root, "lsp-cli.config.json");
+  await fs.writeFile(
+    cfgPath,
+    JSON.stringify(
+      {
+        servers: {
+          mock: {
+            command: process.execPath,
+            args: [serverScript],
+            defaultLanguageId: "plaintext"
+          }
+        }
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  const cli = path.resolve(__dirname, "../cli.js");
+
+  const input = [
+    JSON.stringify({ id: 1, cmd: "references", file, line: 0, col: 0 }),
+    JSON.stringify({ id: 2, cmd: "rename", file, line: 0, col: 0, newName: "X", apply: true }),
+    JSON.stringify({ id: 3, cmd: "request", method: "mock/getInitializeCount" })
+  ].join("\n");
+
+  const res = spawnSync(process.execPath, [cli, "--root", root, "--server", "mock", "--format", "json", "batch", "--apply"], {
+    input,
+    encoding: "utf8"
+  });
+
+  assert.equal(res.status, 0, res.stderr);
+
+  const lines = res.stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+
+  assert.equal(lines.length, 3);
+  assert.equal(lines[0].ok, true);
+  assert.equal(lines[0].id, 1);
+
+  assert.equal(lines[1].ok, true);
+  assert.equal(lines[1].id, 2);
+  assert.equal(lines[1].applied, true);
+
+  assert.equal(lines[2].ok, true);
+  assert.equal(lines[2].id, 3);
+  assert.equal(lines[2].result, 1);
+
+  const updated = await fs.readFile(file, "utf8");
+  assert.equal(updated.startsWith("X"), true);
+});


### PR DESCRIPTION
Closes #23

- Add "batch" command to process JSONL requests on stdin using a single LSP session.
- Supports request/notify passthrough plus common commands (references/definition/rename/code-actions/delete-symbol/etc).
- Adds mock helper mock/getInitializeCount and CLI test to assert initialize happens once.

Notes:
- batch requires --format json and does not support --jq.
- Edits require batch --apply (per-line apply:true still required).
